### PR TITLE
Feature: allow data folder downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.5.0-beta.4
+FROM semtech/mu-javascript-template:1.7.0
 LABEL maintainer=info@redpencil.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.7.0
+FROM semtech/mu-javascript-template:1.5.0-beta.4
 LABEL maintainer=info@redpencil.io

--- a/app.js
+++ b/app.js
@@ -24,8 +24,6 @@ app.get("/download", async (req, res) => {
     //    A. if super-consumer, check session in db
     //    B. or, check normal authorization scheme provided by mu-auth
     let hasAccess = await isValidSuperConsumer(sessionUri) || await hasAccessToFile(puri);
-    console.log("ACCESS?", hasAccess);
-    hasAccess = true;
     // 3. Returning response
     if (!hasAccess) {
       // A. You're not the consumer
@@ -36,10 +34,8 @@ app.get("/download", async (req, res) => {
       let filepath = "";
       if(puri.startsWith('share')){
         filepath = path.normalize(`${SHARE_FOLDER}/${puri.replace("share://", "")}`);
-        console.log('accessed a file in share-------->');
-      } else{
+      } else if (puri.startsWith('data')) {
         filepath = path.normalize(`${DATA_FOLDER}/${puri.replace("data://", "")}`);
-        console.log('accessed a file in data--------->');
       }
 
 

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ import path from "path";
 
 // Environment, constants with defaults
 const SHARE_FOLDER = process.env.SHARE_FOLDER || "/share/";
+const DATA_FOLDER = "/data/";
 const ALLOW_SUPER_CONSUMER = process.env.ALLOW_SUPER_CONSUMER == "true" ? true : false;
 const ALLOWED_ACCOUNTS = process.env.ALLOWED_ACCOUNTS || 'http://services.lblod.info/diff-consumer/account';
 
@@ -22,8 +23,9 @@ app.get("/download", async (req, res) => {
     // 2. Validate access:
     //    A. if super-consumer, check session in db
     //    B. or, check normal authorization scheme provided by mu-auth
-    const hasAccess = await isValidSuperConsumer(sessionUri) || await hasAccessToFile(puri);
-
+    let hasAccess = await isValidSuperConsumer(sessionUri) || await hasAccessToFile(puri);
+    console.log("ACCESS?", hasAccess);
+    hasAccess = true;
     // 3. Returning response
     if (!hasAccess) {
       // A. You're not the consumer
@@ -31,7 +33,15 @@ app.get("/download", async (req, res) => {
     }
     else {
       // B. Authorization is fine: we try to return the file.
-      const filepath = path.normalize(`${SHARE_FOLDER}/${puri.replace("share://", "")}`);
+      let filepath = "";
+      if(puri.startsWith('share')){
+        filepath = path.normalize(`${SHARE_FOLDER}/${puri.replace("share://", "")}`);
+        console.log('accessed a file in share-------->');
+      } else{
+        filepath = path.normalize(`${DATA_FOLDER}/${puri.replace("data://", "")}`);
+        console.log('accessed a file in data--------->');
+      }
+
 
       res.download(filepath, name, err => {
         if (err) {

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ import path from "path";
 
 // Environment, constants with defaults
 const SHARE_FOLDER = process.env.SHARE_FOLDER || "/share/";
-const DATA_FOLDER = "/data/";
+const DATA_FOLDER = process.env.DATA_FOLDER || "/data/";
 const ALLOW_SUPER_CONSUMER = process.env.ALLOW_SUPER_CONSUMER == "true" ? true : false;
 const ALLOWED_ACCOUNTS = process.env.ALLOWED_ACCOUNTS || 'http://services.lblod.info/diff-consumer/account';
 
@@ -23,7 +23,8 @@ app.get("/download", async (req, res) => {
     // 2. Validate access:
     //    A. if super-consumer, check session in db
     //    B. or, check normal authorization scheme provided by mu-auth
-    let hasAccess = await isValidSuperConsumer(sessionUri) || await hasAccessToFile(puri);
+    const hasAccess = await isValidSuperConsumer(sessionUri) || await hasAccessToFile(puri);
+
     // 3. Returning response
     if (!hasAccess) {
       // A. You're not the consumer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "file-service-for-share",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Microservice that serves file like a file-service, but for share:// URIs",
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
 ## Description

 Extend the file-share-sync-service to allow sharing files from the data folder as well. This PR is needed for the sync from Loket to Subsidiedatabank, it allows us to sync over attachment files from subsidies, as well as meta ttl files.

 ## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Other

 ## Related services

 - app-subsidiedatabank
 - app-digitaal-loket

 ## How to test

Use this service in Loket, use a local producer consumer setup. Create subsidies in loket and wait until they are synced over to subsidiedatabank. The subsidies should have downloaded over the attachments as well thanks to this extension.

 ## Links to other PR's

 - TBD